### PR TITLE
sync element heights added - comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@types/node": "^22.15.21",
+        "@uidotdev/usehooks": "^2.4.1",
         "axios": "^1.9.0",
         "bootstrap": "^5.3.6",
         "dompurify": "^3.2.6",
@@ -1504,6 +1505,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uidotdev/usehooks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
+      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react-swc": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@types/node": "^22.15.21",
+    "@uidotdev/usehooks": "^2.4.1",
     "axios": "^1.9.0",
     "bootstrap": "^5.3.6",
     "dompurify": "^3.2.6",

--- a/src/assets/scss/_card.scss
+++ b/src/assets/scss/_card.scss
@@ -15,18 +15,10 @@
 
     & .card-header {
         border: none; padding: 0; margin-bottom: 1rem; background-color: transparent; text-align: center;
-        font-family: $font-family-medium-stack; font-weight: bold; font-size: $font-size-base * 1.2; min-height: auto;
-
-        @media screen and (min-width: 992px) {
-            min-height: 3rem;
-        }
+        font-family: $font-family-medium-stack; font-weight: bold; font-size: $font-size-base * 1.2; 
     }
 
     & .card-body {
         font-weight: 500;
-
-        & .policy-attribute-list-wrapper {
-            min-height: 26rem;
-        }
     }
 }

--- a/src/components/ComparisonCard.tsx
+++ b/src/components/ComparisonCard.tsx
@@ -1,22 +1,45 @@
+import { useRef } from "react"
 import { Fragment } from "react/jsx-runtime"
-//Types
-import type { CompProductProps } from "../types"
 //React Router
 import { Link } from "react-router"
+//Types
+import type { CompProductProps } from "../types"
 //Utilities
 import formatCurrency from "../utilities/formatCurrency"
+//Hooks
+import { useSyncRefHeight } from "./hooks/useSyncRefHeight"
+import { useWindowSize } from "@uidotdev/usehooks" //https://usehooks.com/usewindowsize
 
 export default function ComparisonCard({ title, monthlyCost, excessCost, inclusions, exclusions, policyLink }: CompProductProps) {
+  //Set refs to target the elements we want to set at the same heights (to align the comparison cards aesthetically)
+  const titleRef = useRef(null)
+  const policyInclExclRef = useRef(null)
+
+  //Set a const to use the useWindowSize hook from usehooks.com
+  //This is so we can set a dependency for the useSyncRefHeight to run every time the window changes size (reponsive)
+  const size = useWindowSize()
+  //console.log("size: ", size.width)
+
+  useSyncRefHeight(
+    [
+      ["title", titleRef],
+      ["policyInclExcl", policyInclExclRef],
+    ],
+    [size.width]
+  )
+
   return (
     <div className="col">
       <div className="card comparison-card h-100">
-        <div className="card-header">{title}</div>
+        <div className="card-header" ref={titleRef}>
+          {title}
+        </div>
         <div className="card-body homeserve-medium">
           <div className="text-center mb-4">
             <div className="h5 fw-bold">{formatCurrency(monthlyCost)} a month</div>
             <div>Excess: £{excessCost}</div>
           </div>
-          <div className="policy-attribute-list-wrapper">
+          <div className="policy-attribute-list-wrapper mb-4" ref={policyInclExclRef}>
             <div>
               <p>This policy covers:</p>
               <ul className="included">
@@ -31,7 +54,7 @@ export default function ComparisonCard({ title, monthlyCost, excessCost, inclusi
                   <hr></hr>
                   <div>
                     <p className="text-gray">Other policies are available which also cover:</p>
-                    <ul className="excluded">
+                    <ul className="excluded mb-0">
                       {exclusions.map((exclusion, index) => {
                         return <li key={index}>{exclusion}</li>
                       })}

--- a/src/components/LandlordComparisonCard.tsx
+++ b/src/components/LandlordComparisonCard.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react"
 import { Fragment } from "react/jsx-runtime"
 //Types
 import type { LandlordCompProductProps } from "../types"
@@ -5,17 +6,39 @@ import type { LandlordCompProductProps } from "../types"
 import { Link } from "react-router"
 //Utilities
 import formatCurrency from "../utilities/formatCurrency"
+//Hooks
+import { useSyncRefHeight } from "./hooks/useSyncRefHeight"
+import { useWindowSize } from "@uidotdev/usehooks" //https://usehooks.com/usewindowsize
 
 export default function LandlordComparisonCard({ title, monthlyCost, inclusions, exclusions, policyLink }: LandlordCompProductProps) {
+  //Set refs to target the elements we want to set at the same heights (to align the comparison cards aesthetically)
+  const titleRef = useRef(null)
+  const policyInclExclRef = useRef(null)
+
+  //Set a const to use the useWindowSize hook from usehooks.com
+  //This is so we can set a dependency for the useSyncRefHeight to run every time the window changes size (reponsive)
+  const size = useWindowSize()
+  //console.log("size: ", size.width)
+
+  useSyncRefHeight(
+    [
+      ["title", titleRef],
+      ["policyInclExcl", policyInclExclRef],
+    ],
+    [size.width]
+  )
+
   return (
     <div className="col">
       <div className="card comparison-card h-100">
-        <div className="card-header">{title}</div>
+        <div className="card-header" ref={titleRef}>
+          {title}
+        </div>
         <div className="card-body homeserve-medium">
           <div className="text-center mb-4">
             <div className="h5 fw-bold">{formatCurrency(monthlyCost)} a month</div>
           </div>
-          <div className="policy-attribute-list-wrapper">
+          <div className="policy-attribute-list-wrapper mb-4" ref={policyInclExclRef}>
             <div>
               <p>This policy covers:</p>
               <ul className="included">

--- a/src/components/hooks/useSyncRefHeight.ts
+++ b/src/components/hooks/useSyncRefHeight.ts
@@ -1,0 +1,94 @@
+//Example
+//https://dev.to/9zemian5/sync-height-between-elements-in-react-1fg0
+
+import { useLayoutEffect, type RefObject } from "react"
+
+type Target = RefObject<HTMLElement | null>
+
+//Store all elements per key, so it is easy to retrieve them
+const store: Record<string, Target[]> = {}
+
+// Triggered when useLayoutEffect is executed on any of the components that use useSyncRefHeight hook
+const handleResize = (key: string) => {
+  //Get the window's inner width
+  //For small mobile when each main element generally tends to stack, we don't want the heights to sync
+  const windowSize = window.innerWidth
+  //Maximum window width setting (small mobile)
+  const maxWidth = 575
+
+  //Get all elements with the same key
+  const elements = store[key]
+  if (elements) {
+    let max = 0
+
+    //Reset height of all elements on each window resize
+    elements.forEach((element) => {
+      if (element.current) {
+        element.current.style.minHeight = "0px"
+      }
+    })
+
+    //Find the element with highest clientHeight value
+    elements.forEach((element) => {
+      if (element.current && element.current.clientHeight > max) {
+        max = element.current.clientHeight
+      }
+    })
+
+    //Update height of all 'joined' elements
+    elements.forEach((element) => {
+      if (element.current) {
+        if (windowSize > maxWidth) {
+          element.current.style.minHeight = `${max}px`
+        } else {
+          element.current.style.minHeight = "auto"
+        }
+      }
+    })
+  }
+}
+
+//Add element to the store when component is mounted and return cleanup function
+const add = (key: string, element: Target) => {
+  //Create store if missing
+  if (!store[key]) {
+    store[key] = []
+  }
+
+  store[key].push(element)
+
+  //Cleanup function
+  return () => {
+    const index = store[key].indexOf(element)
+    if (index > -1) {
+      store[key].splice(index, 1)
+    }
+  }
+}
+
+//Receives multiple elements ([key, element] pairs). This way one hook can be used to handle multiple elements
+export type UseSyncRefHeightProps = Array<[string, Target]>
+
+export const useSyncRefHeight = (refs: UseSyncRefHeightProps, deps?: any[]) => {
+  useLayoutEffect(() => {
+    //Store cleanup functions for each entry
+    const cleanups: (() => void)[] = []
+
+    refs.forEach(([key, element]) => {
+      //Add element ref to store
+      cleanups.push(add(key, element))
+    })
+
+    return () => {
+      //Cleanup when component is destroyed
+      cleanups.forEach((cleanup) => cleanup())
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    //When any of the dependencies changes, update all elements heights
+    refs.forEach(([key]) => {
+      handleResize(key)
+    })
+  }, deps)
+}


### PR DESCRIPTION
-added a hook to sync the heights of parts of a component to help with listed component alignment (ltr)
-comparison & landlord-comparison components updated
     - title and inclusions/exclusions section targeted to align the price and CTAs